### PR TITLE
Adds trim@0.0.1 (MIT)

### DIFF
--- a/index.csv
+++ b/index.csv
@@ -5992,3 +5992,4 @@ underscore,1.4.1,MIT
 underscore,1.4.2,MIT
 underscore,1.4.3,MIT
 underscore,1.4.4,MIT
+trim,0.0.1,MIT


### PR DESCRIPTION
The [`trim`](https://www.npmjs.com/package/trim) ReadMe contains the full MIT license.

- [ ] Are you the package author?
- [x] Downloaded, extracted, and reviewed the contents of the package tarball on the npm public registry.
- [x] Checked `README`, `LICENSE`, `COPYING`, and header comments for conflicting or additional licenses.
- [x] Searched for "license", such as with `fgrep -ir license $PACKAGE_DIRECTORY`.
- [x] Compared the license text found to standard language on <htts://spdx.org/licenses/>.
- [ ] Asked the package author about the applicable license.