### PR TITLE
Update contributing guidelines & fix typo

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,5 +2,5 @@
 - [ ] Downloaded, extracted, and reviewed the contents of the package tarball on the npm public registry.
 - [ ] Checked `README`, `LICENSE`, `COPYING`, and header comments for conflicting or additional licenses.
 - [ ] Searched for "license", such as with `fgrep -ir license $PACKAGE_DIRECTORY`.
-- [ ] Compared the license text found to standard language on <htts://spdx.org/licenses/>.
+- [ ] Compared the license text found to standard language on <https://spdx.org/licenses/>.
 - [ ] Asked the package author about the applicable license.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
-Edit [`index.csv`](./index.csv).  `npm run prepublish` generates `index.json` from `index.csv`. 
+Edit [`index.csv`](./index.csv).  `npm run prepublish` generates `index.json` from `index.csv`.
+
+Check the [pull request template](./.github/pull_request_template.md) for guidelines on what to do when adding or updating a package.
 
 Note that command-line Git can do union merge on `index.csv` to avoid merge conflicts, while GitHub's merge button cannot.


### PR DESCRIPTION
1. Update the Contributing Guidelines to point to the PR template so that contributors have a better idea what is expected of them when adding or updating a package _before_ opening a PR.
2. Fix a typo in the pull request template.